### PR TITLE
ci: use Gradle cache from actions/setup-java

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,20 +19,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2.3.0
         with:
           distribution: adopt
           java-version: ${{ matrix.java-version }}
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-java${{ matrix.java-version }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-java${{ matrix.java-version }}-
+          cache: gradle
 
       # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle
       - name: Validate Gradle wrapper
@@ -47,13 +38,6 @@ jobs:
         with:
           name: Test report
           path: de.unibonn.simpleml.tests/build/reports/tests/test
-
-      # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-      # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-      - name: Cleanup Gradle cache
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties
 
   # Build and test Frontend component
   build-frontend:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,20 +28,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2.2.0
+        uses: actions/setup-java@v2.3.0
         with:
           distribution: adopt
           java-version: ${{ matrix.java-version }}
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-java${{ matrix.java-version }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-java${{ matrix.java-version }}-
+          cache: gradle
 
       # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-gradle
       - name: Validate Gradle wrapper
@@ -56,13 +47,6 @@ jobs:
         with:
           name: Test report
           path: de.unibonn.simpleml.tests/build/reports/tests/test
-
-      # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-      # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-      - name: Cleanup Gradle cache
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties
 
   # Build and test Frontend component
   build-frontend:


### PR DESCRIPTION
Closes #51.

## Summary of Changes

Use Gradle cache from actions/setup-java rather than using actions/cache directly.