### PR TITLE
fix: ClassNotFoundException when using jettyRun with Gradle

### DIFF
--- a/DSL/de.unibonn.simpleml.web/build.gradle.kts
+++ b/DSL/de.unibonn.simpleml.web/build.gradle.kts
@@ -2,7 +2,6 @@ val javaSourceVersion: JavaVersion by rootProject.extra
 val javaTargetVersion: JavaVersion by rootProject.extra
 val xtextVersion: String by rootProject.extra
 
-
 // Plugins -------------------------------------------------------------------------------------------------------------
 
 plugins {
@@ -17,22 +16,20 @@ java {
     targetCompatibility = javaTargetVersion
 }
 
-
 // Dependencies --------------------------------------------------------------------------------------------------------
 
 dependencies {
     implementation(project(":de.unibonn.simpleml"))
-    implementation("org.eclipse.xtend:org.eclipse.xtend.lib:${xtextVersion}")
+    implementation("org.eclipse.xtend:org.eclipse.xtend.lib:$xtextVersion")
     implementation("org.emfjson:emfjson-jackson:1.2.0")
 
     api(project(":de.unibonn.simpleml.ide"))
-    api("org.eclipse.xtext:org.eclipse.xtext.xbase.web:${xtextVersion}")
-    api("org.eclipse.xtext:org.eclipse.xtext.web.servlet:${xtextVersion}")
+    api("org.eclipse.xtext:org.eclipse.xtext.xbase.web:$xtextVersion")
+    api("org.eclipse.xtext:org.eclipse.xtext.web.servlet:$xtextVersion")
 
     providedCompile("org.eclipse.jetty:jetty-annotations:9.4.22.v20191022")
     providedCompile("org.slf4j:slf4j-simple:1.7.32")
 }
-
 
 // Source sets ---------------------------------------------------------------------------------------------------------
 
@@ -41,7 +38,6 @@ sourceSets {
         java.srcDirs("src", "src-gen")
     }
 }
-
 
 // Tasks ---------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary of Changes

Fixes this issue with `./gradlew jettyRun`:

```
> ./gradlew jettyRun
> Task :de.unibonn.simpleml.web:jettyRun FAILED
Exception in thread “main” java.lang.NoClassDefFoundError: org/eclipse/jetty/server/Server
        at de.unibonn.simpleml.web.ServerLauncher$Companion.main(ServerLauncher.kt:22)
        at de.unibonn.simpleml.web.ServerLauncher.main(ServerLauncher.kt)
Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.server.Server
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 2 more
```

## Testing instructions

Check if `./gradlew jettyRun` works now.
