### PR TITLE
build: specify Java toolchain

### DIFF
--- a/DSL/README.md
+++ b/DSL/README.md
@@ -24,7 +24,6 @@ Note: This solution requires that Git itself can clone this private repository f
 
 ### Option 2: Custom Installation
 
-1. Install [OpenJDK 11](https://adoptopenjdk.net/).
 1. Install [Node.js](https://nodejs.org/en/).
 1. Install [VS Code](https://code.visualstudio.com/).
 1. Clone this repository.

--- a/DSL/build.gradle.kts
+++ b/DSL/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 // Plugins -------------------------------------------------------------------------------------------------------------
 
 plugins {
@@ -15,8 +17,7 @@ idea {
 
 // Variables -----------------------------------------------------------------------------------------------------------
 
-val javaSourceVersion by extra(JavaVersion.VERSION_11)
-val javaTargetVersion by extra(JavaVersion.VERSION_11)
+val javaVersion by extra(11)
 val xtextVersion by extra("2.26.0.M2")
 
 // Subprojects ---------------------------------------------------------------------------------------------------------
@@ -31,11 +32,5 @@ subprojects {
 
     configurations.all {
         exclude(group = "asm")
-    }
-
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = javaTargetVersion.majorVersion
-        }
     }
 }

--- a/DSL/de.unibonn.simpleml.ide/build.gradle.kts
+++ b/DSL/de.unibonn.simpleml.ide/build.gradle.kts
@@ -1,5 +1,4 @@
-val javaSourceVersion: JavaVersion by rootProject.extra
-val javaTargetVersion: JavaVersion by rootProject.extra
+val javaVersion: Int by rootProject.extra
 val xtextVersion: String by rootProject.extra
 
 // Plugins -------------------------------------------------------------------------------------------------------------
@@ -11,8 +10,9 @@ plugins {
 }
 
 java {
-    sourceCompatibility = javaSourceVersion
-    targetCompatibility = javaTargetVersion
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+    }
 }
 
 application {

--- a/DSL/de.unibonn.simpleml.tests/build.gradle.kts
+++ b/DSL/de.unibonn.simpleml.tests/build.gradle.kts
@@ -1,5 +1,4 @@
-val javaSourceVersion: JavaVersion by rootProject.extra
-val javaTargetVersion: JavaVersion by rootProject.extra
+val javaVersion: Int by rootProject.extra
 val xtextVersion: String by rootProject.extra
 
 // Plugins -------------------------------------------------------------------------------------------------------------
@@ -10,8 +9,9 @@ plugins {
 }
 
 java {
-    sourceCompatibility = javaSourceVersion
-    targetCompatibility = javaTargetVersion
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+    }
 }
 
 // Dependencies --------------------------------------------------------------------------------------------------------

--- a/DSL/de.unibonn.simpleml.web/build.gradle.kts
+++ b/DSL/de.unibonn.simpleml.web/build.gradle.kts
@@ -1,5 +1,4 @@
-val javaSourceVersion: JavaVersion by rootProject.extra
-val javaTargetVersion: JavaVersion by rootProject.extra
+val javaVersion: Int by rootProject.extra
 val xtextVersion: String by rootProject.extra
 
 // Plugins -------------------------------------------------------------------------------------------------------------
@@ -12,8 +11,9 @@ plugins {
 }
 
 java {
-    sourceCompatibility = javaSourceVersion
-    targetCompatibility = javaTargetVersion
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+    }
 }
 
 // Dependencies --------------------------------------------------------------------------------------------------------

--- a/DSL/de.unibonn.simpleml/build.gradle.kts
+++ b/DSL/de.unibonn.simpleml/build.gradle.kts
@@ -1,5 +1,4 @@
-val javaSourceVersion: JavaVersion by rootProject.extra
-val javaTargetVersion: JavaVersion by rootProject.extra
+val javaVersion: Int by rootProject.extra
 val xtextVersion: String by rootProject.extra
 
 
@@ -12,8 +11,9 @@ plugins {
 }
 
 java {
-    sourceCompatibility = javaSourceVersion
-    targetCompatibility = javaTargetVersion
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+    }
 }
 
 idea {
@@ -107,5 +107,3 @@ tasks {
         dependsOn("cleanGenerateXtextLanguage")
     }
 }
-
-


### PR DESCRIPTION
## Summary of Changes

* Use [Gradle toolchain](https://docs.gradle.org/current/userguide/toolchains.html) to setup JDK 11 for all developers
