### PR TITLE
fix: wrap negative int & floats into a prefix operation

### DIFF
--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
@@ -91,6 +91,7 @@ import de.unibonn.simpleml.simpleML.SmlYield
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.xtext.resource.XtextResource
+import kotlin.math.absoluteValue
 
 private val factory = SimpleMLFactory.eINSTANCE
 
@@ -621,11 +622,17 @@ fun SmlStep.smlExpressionStatement(expression: SmlAbstractExpression) {
 }
 
 /**
- * Returns a new object of class [SmlFloat].
+ * Returns a new object of class [SmlFloat] if the value is non-negative. Otherwise, the absolute value will be wrapped
+ * in a [SmlPrefixOperation] to negate it.
  */
-fun createSmlFloat(value: Double): SmlFloat {
-    return factory.createSmlFloat().apply {
-        this.value = value
+fun createSmlFloat(value: Double): SmlAbstractExpression {
+    val float = factory.createSmlFloat().apply {
+        this.value = value.absoluteValue
+    }
+
+    return when {
+        value < 0 -> createSmlPrefixOperation(SmlPrefixOperationOperator.Minus, float)
+        else -> float
     }
 }
 
@@ -766,11 +773,17 @@ fun createSmlInfixOperation(
 }
 
 /**
- * Returns a new object of class [SmlInt].
+ * Returns a new object of class [SmlInt] if the value is non-negative. Otherwise, the absolute value will be wrapped in
+ * a [SmlPrefixOperation] to negate it.
  */
-fun createSmlInt(value: Int): SmlInt {
-    return factory.createSmlInt().apply {
-        this.value = value
+fun createSmlInt(value: Int): SmlAbstractExpression {
+    val int = factory.createSmlInt().apply {
+        this.value = value.absoluteValue
+    }
+
+    return when {
+        value < 0 -> createSmlPrefixOperation(SmlPrefixOperationOperator.Minus, int)
+        else -> int
     }
 }
 

--- a/DSL/de.unibonn.simpleml/src/test/kotlin/de/unibonn/simpleml/emf/CreatorsTest.kt
+++ b/DSL/de.unibonn.simpleml/src/test/kotlin/de/unibonn/simpleml/emf/CreatorsTest.kt
@@ -1,16 +1,20 @@
 package de.unibonn.simpleml.emf
 
 import de.unibonn.simpleml.constant.SmlFileExtension
+import de.unibonn.simpleml.constant.SmlPrefixOperationOperator
 import de.unibonn.simpleml.constant.SmlProtocolTokenClassValue
 import de.unibonn.simpleml.constant.SmlTypeParameterConstraintOperator
 import de.unibonn.simpleml.serializer.SerializationResult
 import de.unibonn.simpleml.serializer.serializeToFormattedString
+import de.unibonn.simpleml.simpleML.SmlFloat
 import de.unibonn.simpleml.simpleML.SmlInt
+import de.unibonn.simpleml.simpleML.SmlPrefixOperation
 import de.unibonn.simpleml.simpleML.SmlProtocol
 import de.unibonn.simpleml.simpleML.SmlTemplateStringEnd
 import de.unibonn.simpleml.simpleML.SmlTemplateStringInner
 import de.unibonn.simpleml.simpleML.SmlTemplateStringStart
 import de.unibonn.simpleml.testing.SimpleMLInjectorProvider
+import de.unibonn.simpleml.testing.assertions.shouldBeCloseTo
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
@@ -406,6 +410,18 @@ class CreatorsTest {
     }
 
     @Test
+    fun `createSmlFloat should wrap negative numbers in a prefix operation (-)`() {
+        val float = createSmlFloat(-1.0)
+
+        float.shouldBeInstanceOf<SmlPrefixOperation>()
+        float.operator shouldBe SmlPrefixOperationOperator.Minus.operator
+
+        val operand = float.operand
+        operand.shouldBeInstanceOf<SmlFloat>()
+        operand.value shouldBeCloseTo 1.0
+    }
+
+    @Test
     fun `createSmlFunction should store annotation uses in annotationUseHolder`() {
         val function = createSmlFunction(
             "test",
@@ -473,6 +489,18 @@ class CreatorsTest {
         }
 
         `package`.members.shouldHaveSize(1)
+    }
+
+    @Test
+    fun `createSmlInt should wrap negative numbers in a prefix operation (-)`() {
+        val int = createSmlInt(-1)
+
+        int.shouldBeInstanceOf<SmlPrefixOperation>()
+        int.operator shouldBe SmlPrefixOperationOperator.Minus.operator
+
+        val operand = int.operand
+        operand.shouldBeInstanceOf<SmlInt>()
+        operand.value shouldBe 1
     }
 
     @Test


### PR DESCRIPTION
## Summary of Changes

Ints or floats with negative value cannot be serialized. They need to be wrapped in a prefix operation with `-` as the operator. This is now handled automatically in the creators.
