### PR TITLE
feat: error if class/enum are statically referenced

### DIFF
--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/SimpleMLValidator.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/SimpleMLValidator.kt
@@ -21,6 +21,7 @@ import de.unibonn.simpleml.validation.expressions.CallChecker
 import de.unibonn.simpleml.validation.expressions.InfixOperationChecker
 import de.unibonn.simpleml.validation.expressions.LambdaChecker
 import de.unibonn.simpleml.validation.expressions.MemberAccessChecker
+import de.unibonn.simpleml.validation.expressions.ReferenceChecker
 import de.unibonn.simpleml.validation.expressions.TemplateStringChecker
 import de.unibonn.simpleml.validation.other.AnnotationCallChecker
 import de.unibonn.simpleml.validation.other.ArgumentListChecker
@@ -68,6 +69,7 @@ import org.eclipse.xtext.validation.ComposedChecks
         InfixOperationChecker::class,
         LambdaChecker::class,
         MemberAccessChecker::class,
+        ReferenceChecker::class,
         TemplateStringChecker::class,
 
         // Statements

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/codes/ErrorCode.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/codes/ErrorCode.kt
@@ -71,4 +71,7 @@ enum class ErrorCode {
     UnassignedResult,
     DuplicateResultAssignment,
     MustBeConstant,
+
+    MustNotStaticallyReferenceClass,
+    MustNotStaticallyReferenceEnum,
 }

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/expressions/ReferenceChecker.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/expressions/ReferenceChecker.kt
@@ -1,0 +1,63 @@
+package de.unibonn.simpleml.validation.expressions
+
+import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals
+import de.unibonn.simpleml.simpleML.SmlAbstractChainedExpression
+import de.unibonn.simpleml.simpleML.SmlClass
+import de.unibonn.simpleml.simpleML.SmlEnum
+import de.unibonn.simpleml.simpleML.SmlMemberAccess
+import de.unibonn.simpleml.simpleML.SmlReference
+import de.unibonn.simpleml.validation.AbstractSimpleMLChecker
+import de.unibonn.simpleml.validation.codes.ErrorCode
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.validation.Check
+
+class ReferenceChecker : AbstractSimpleMLChecker() {
+
+    @Check
+    fun mustNotStaticallyReferenceClass(smlReference: SmlReference) {
+        if (smlReference.declaration !is SmlClass) {
+            return
+        }
+
+        // Reference must eventually be the receiver of a chained expression
+        var previous: EObject = smlReference
+        var current: EObject = previous.eContainer()
+        while (current is SmlAbstractChainedExpression) {
+            if (current.receiver == previous) {
+                return
+            }
+            previous = current
+            current = current.eContainer()
+        }
+
+        error(
+            "Must not statically reference class.",
+            Literals.SML_REFERENCE__DECLARATION,
+            ErrorCode.MustNotStaticallyReferenceClass
+        )
+    }
+
+    @Check
+    fun mustNotStaticallyReferenceEnum(smlReference: SmlReference) {
+        if (smlReference.declaration !is SmlEnum) {
+            return
+        }
+
+        // Reference must eventually be the receiver of a member access
+        var previous: EObject = smlReference
+        var current: EObject = previous.eContainer()
+        while (current is SmlMemberAccess) {
+            if (current.receiver == previous) {
+                return
+            }
+            previous = current
+            current = current.eContainer()
+        }
+
+        error(
+            "Must not statically reference enum.",
+            Literals.SML_REFERENCE__DECLARATION,
+            ErrorCode.MustNotStaticallyReferenceEnum
+        )
+    }
+}

--- a/DSL/de.unibonn.simpleml/src/test/resources/validation/expressions/references/must not statically reference class.smltest
+++ b/DSL/de.unibonn.simpleml/src/test/resources/validation/expressions/references/must not statically reference class.smltest
@@ -1,0 +1,35 @@
+package tests.validation.references.mustNotStaticallyReferenceClass
+
+class ClassWithConstructor()
+
+class ClassWithoutConstructor
+
+class ClassWithStaticMembers {
+    static attr myAttribute: Int
+
+    class InnerClassWithConstructor() {
+        static attr myAttribute: Int
+    }
+}
+
+workflow test {
+    // semantic_error "Must not statically reference class."
+    »ClassWithConstructor«;    
+    // no_semantic_error "Must not statically reference class."
+    »ClassWithoutConstructor«();
+    // no_semantic_error "Must not statically reference class."
+    »ClassWithConstructor«();
+    // no_semantic_error "Must not statically reference class."
+    »ClassWithStaticMembers«.myAttribute;    
+    // no_semantic_error "Must not statically reference class."
+    »ClassWithStaticMembers«.unresolved;
+    // no_semantic_error "Must not statically reference class."
+    // semantic_error "Must not statically reference class."
+    »ClassWithStaticMembers«.»InnerClassWithConstructor«;
+    // no_semantic_error "Must not statically reference class."
+    // no_semantic_error "Must not statically reference class."
+    »ClassWithStaticMembers«.»InnerClassWithConstructor«();    
+    // no_semantic_error "Must not statically reference class."
+    // no_semantic_error "Must not statically reference class."
+    »ClassWithStaticMembers«.»InnerClassWithConstructor«.myAttribute;
+}

--- a/DSL/de.unibonn.simpleml/src/test/resources/validation/expressions/references/must not statically reference enum.smltest
+++ b/DSL/de.unibonn.simpleml/src/test/resources/validation/expressions/references/must not statically reference enum.smltest
@@ -1,0 +1,36 @@
+package tests.validation.references.mustNotStaticallyReferenceEnum
+
+enum Enum {
+    Variant
+}
+
+class ClassWithEnum {
+    enum Enum {
+        Variant
+    }
+
+    class ClassWithEnum {
+        enum Enum {
+            Variant
+        }
+    }
+}
+
+workflow test {
+    // semantic_error "Must not statically reference enum."
+    »Enum«;    
+    // semantic_error "Must not statically reference enum."
+    »Enum«();
+    // no_semantic_error "Must not statically reference enum."
+    »Enum«.Variant;        
+    // no_semantic_error "Must not statically reference enum."
+    »Enum«.unresolved;    
+    // semantic_error "Must not statically reference enum."
+    ClassWithEnum.»Enum«;
+    // no_semantic_error "Must not statically reference enum."
+    ClassWithEnum.»Enum«.Variant;    
+    // semantic_error "Must not statically reference enum."
+    ClassWithEnum.ClassWithEnum.»Enum«;
+    // no_semantic_error "Must not statically reference enum."
+    ClassWithEnum.ClassWithEnum.»Enum«.Variant;
+}


### PR DESCRIPTION
## Summary of Changes

* Error if enum is referenced outside a member access. Example:
  ```
  enum Enum {
      Variant
  }
  
  workflow test {
      »Enum«;
  }
  ```
* Error if class is referenced outside call or member access. Example:
  ```
  class Class
  
  workflow test {
      »Class«; 
  }
  ```
* It's not possible to assign a type to those expressions, which is why this should be forbidden.