### PR TITLE
feat: allow direct references to classes with constructor

### DIFF
--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/expressions/ReferenceChecker.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/expressions/ReferenceChecker.kt
@@ -15,7 +15,8 @@ class ReferenceChecker : AbstractSimpleMLChecker() {
 
     @Check
     fun mustNotStaticallyReferenceClass(smlReference: SmlReference) {
-        if (smlReference.declaration !is SmlClass) {
+        val declaration = smlReference.declaration
+        if (declaration !is SmlClass || declaration.parameterList != null) {
             return
         }
 

--- a/DSL/de.unibonn.simpleml/src/test/resources/validation/expressions/references/must not statically reference class.smltest
+++ b/DSL/de.unibonn.simpleml/src/test/resources/validation/expressions/references/must not statically reference class.smltest
@@ -10,25 +10,32 @@ class ClassWithStaticMembers {
     class InnerClassWithConstructor() {
         static attr myAttribute: Int
     }
+    
+    class InnerClassWithoutConstructor
 }
 
 workflow test {
+    // no_semantic_error "Must not statically reference class."
+    »ClassWithConstructor«;
     // semantic_error "Must not statically reference class."
-    »ClassWithConstructor«;    
+    »ClassWithoutConstructor«;
     // no_semantic_error "Must not statically reference class."
     »ClassWithoutConstructor«();
     // no_semantic_error "Must not statically reference class."
     »ClassWithConstructor«();
     // no_semantic_error "Must not statically reference class."
-    »ClassWithStaticMembers«.myAttribute;    
+    »ClassWithStaticMembers«.myAttribute;
     // no_semantic_error "Must not statically reference class."
     »ClassWithStaticMembers«.unresolved;
     // no_semantic_error "Must not statically reference class."
-    // semantic_error "Must not statically reference class."
+    // no_semantic_error "Must not statically reference class."
     »ClassWithStaticMembers«.»InnerClassWithConstructor«;
     // no_semantic_error "Must not statically reference class."
+    // semantic_error "Must not statically reference class."
+    »ClassWithStaticMembers«.»InnerClassWithoutConstructor«;
     // no_semantic_error "Must not statically reference class."
-    »ClassWithStaticMembers«.»InnerClassWithConstructor«();    
+    // no_semantic_error "Must not statically reference class."
+    »ClassWithStaticMembers«.»InnerClassWithConstructor«();
     // no_semantic_error "Must not statically reference class."
     // no_semantic_error "Must not statically reference class."
     »ClassWithStaticMembers«.»InnerClassWithConstructor«.myAttribute;


### PR DESCRIPTION
## Summary of Changes

* No longer show an error if a class is referenced outside a call or member access if it has a constructor. It then serves as a reference to the constructor.