### PR TITLE
feat: restrict context of lambdas

### DIFF
--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Traversal.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Traversal.kt
@@ -19,8 +19,8 @@ inline fun <reified T : EObject> EObject.descendants(crossinline prune: (EObject
 }
 
 /**
- * Returns the closest ancestor of this [EObject] with the given type or `null` if none exists. This can the this
- * [EObject] itself.
+ * Returns the closest ancestor of this [EObject] with the given type or `null` if none exists. This cannot return the
+ * receiver.
  */
 inline fun <reified T : EObject> EObject.closestAncestorOrNull(): T? {
     var current: EObject? = this.eContainer()
@@ -28,4 +28,16 @@ inline fun <reified T : EObject> EObject.closestAncestorOrNull(): T? {
         current = current.eContainer()
     }
     return current as T?
+}
+
+/**
+ * Returns the closest ancestor of this [EObject] that matches the given [predicate] or `null` if none
+ * exists. This cannot return the receiver.
+ */
+inline fun EObject.closestAncestorOrNull(crossinline predicate: (EObject) -> Boolean = { true }): EObject? {
+    var current: EObject? = this.eContainer()
+    while (current != null && !predicate(current)) {
+        current = current.eContainer()
+    }
+    return current
 }

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/codes/ErrorCode.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/codes/ErrorCode.kt
@@ -77,4 +77,6 @@ enum class ErrorCode {
     DivisionByZero,
 
     UnsupportedAnnotationParameterType,
+
+    LambdaMustBeTypedArgumentOrYielded
 }

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/expressions/LambdaChecker.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/expressions/LambdaChecker.kt
@@ -1,10 +1,19 @@
 package de.unibonn.simpleml.validation.expressions
 
+import de.unibonn.simpleml.emf.assigneesOrEmpty
+import de.unibonn.simpleml.emf.closestAncestorOrNull
 import de.unibonn.simpleml.emf.lambdaResultsOrEmpty
 import de.unibonn.simpleml.emf.parametersOrEmpty
 import de.unibonn.simpleml.emf.placeholdersOrEmpty
+import de.unibonn.simpleml.simpleML.SmlAbstractLambda
+import de.unibonn.simpleml.simpleML.SmlArgument
+import de.unibonn.simpleml.simpleML.SmlAssignment
 import de.unibonn.simpleml.simpleML.SmlBlockLambda
+import de.unibonn.simpleml.simpleML.SmlParenthesizedExpression
+import de.unibonn.simpleml.simpleML.SmlYield
+import de.unibonn.simpleml.staticAnalysis.linking.parameterOrNull
 import de.unibonn.simpleml.validation.AbstractSimpleMLChecker
+import de.unibonn.simpleml.validation.codes.ErrorCode
 import org.eclipse.xtext.validation.Check
 
 class LambdaChecker : AbstractSimpleMLChecker() {
@@ -15,6 +24,30 @@ class LambdaChecker : AbstractSimpleMLChecker() {
             smlBlockLambda.parametersOrEmpty() + smlBlockLambda.placeholdersOrEmpty() + smlBlockLambda.lambdaResultsOrEmpty()
         declarations.reportDuplicateNames {
             "A parameter, result or placeholder with name '${it.name}' exists already in this lambda."
+        }
+    }
+
+    @Check
+    fun context(smlLambda: SmlAbstractLambda) {
+        val context = smlLambda.closestAncestorOrNull { it !is SmlParenthesizedExpression } ?: return
+
+        val contextIsValid = when (context) {
+            is SmlArgument -> {
+                when (val parameter = context.parameterOrNull()) {
+                    null -> true // Resolution of parameter failed, so this already shows another error
+                    else -> parameter.type != null
+                }
+            }
+            is SmlAssignment -> context.assigneesOrEmpty().firstOrNull() is SmlYield
+            else -> false
+        }
+
+        if (!contextIsValid) {
+            error(
+                "A lambda must either be yielded in a step or assigned to a typed parameter.",
+                null,
+                ErrorCode.LambdaMustBeTypedArgumentOrYielded
+            )
         }
     }
 }

--- a/DSL/de.unibonn.simpleml/src/test/resources/validation/expressions/lambdas/context.smltest
+++ b/DSL/de.unibonn.simpleml/src/test/resources/validation/expressions/lambdas/context.smltest
@@ -1,0 +1,88 @@
+package tests.validation.expressions.lambdas.context
+
+workflow invalidCases {
+    // semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    »() {}«;
+    // semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    »() -> 1«;
+    // semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    »() {}«();
+    // semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    (»() {}«)();
+    // semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    (»() -> 1«)();
+    // semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    val a = »() {}«;
+    // semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    val b = »() -> 1«;
+}
+
+step yieldBlockLambdaInStep() -> f: () -> res: Int {
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    yield f = »() { 
+        yield res = 1;
+    }«;
+}
+
+step yieldExpressionLambdaInStep() -> f: () -> res: Int {
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    yield f = »() -> 1«;
+}
+
+step passLambdasAsArgumentToCallableType(f: (g: () -> res: Int) -> ()) {
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    f(»() { yield res = 1; }«);
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    f(»() -> 1«);
+}
+
+class TestClass(f: () -> res: Int)
+enum TestEnum {
+    Variant(f: () -> res: Int)
+}
+fun testFunction(f: () -> res: Int)
+step testStep1(f: () -> res: Int) {}
+
+workflow passLambdasAsArguments {
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    TestClass(»() { yield res = 1; }«);
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    TestClass(»() -> 1«);
+    
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    TestEnum.Variant(»() { yield res = 1; }«);
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    TestEnum.Variant(»() -> 1«);
+    
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    testFunction(»() { yield res = 1; }«);
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    testFunction(»() -> 1«);
+    
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    testStep1(»() { yield res = 1; }«);
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    testStep1(»() -> 1«);
+}
+
+/* Special cases */
+
+workflow wrappedInParentheses {
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    testFunction((»() -> 1«));
+}
+
+step testStep2(param) {}
+
+step testStep3() {}
+
+workflow parameterHasNoType {
+    // semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    testStep2(»() -> 1«);       
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    testStep2(param2 = »() -> 1«);    
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    testStep3(»() -> 1«);    
+    // no_semantic_error "A lambda must either be yielded in a step or assigned to a typed parameter."
+    unresolved(»() -> 1«);
+}


### PR DESCRIPTION
Closes https://github.com/lars-reimann/Simple-ML/issues/106.

## Summary of Changes

* Lambdas can now only be used in the following context:
  1. Yielded in a step
  2. Assigned to a typed parameter.

This ensures that the types of the parameters of the lambdas can be inferred, which is essential for checking the body of the lambda and offering any tooling like auto-completion. The the linked issue for more details regarding this decision.