### PR TITLE
fix: creators for lambdas

### DIFF
--- a/DSL/de.unibonn.simpleml/model/SimpleML.ecore
+++ b/DSL/de.unibonn.simpleml/model/SimpleML.ecore
@@ -110,7 +110,7 @@
     <eClassifiers xsi:type="ecore:EClass" name="SmlParameterList" eSuperTypes="#//SmlAbstractObject">
         <eStructuralFeatures xsi:type="ecore:EReference" name="parameters" upperBound="-1" eType="#//SmlParameter" containment="true" />
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="SmlLambdaParameterList" eSuperTypes="#//SmlAbstractLambda #//SmlParameterList" />
+    <eClassifiers xsi:type="ecore:EClass" name="SmlLambdaParameterList" eSuperTypes="#//SmlAbstractExpression #//SmlParameterList" />
     <eClassifiers xsi:type="ecore:EClass" name="SmlParameter" eSuperTypes="#//SmlAbstractLocalVariable">
         <eStructuralFeatures xsi:type="ecore:EReference" name="defaultValue" eType="#//SmlAbstractExpression" containment="true" />
         <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="#//SmlAbstractType" containment="true" />

--- a/DSL/de.unibonn.simpleml/model/SimpleML.genmodel
+++ b/DSL/de.unibonn.simpleml/model/SimpleML.genmodel
@@ -174,9 +174,7 @@
         <genClasses ecoreClass="SimpleML.ecore#//SmlTemplateStringInner" />
         <genClasses ecoreClass="SimpleML.ecore#//SmlTemplateStringEnd" />
         <genClasses image="false" ecoreClass="SimpleML.ecore#//SmlAbstractLambda" />
-        <genClasses ecoreClass="SimpleML.ecore#//SmlLambdaParameterList">
-            <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SimpleML.ecore#//SmlLambdaParameterList/parameters" />
-        </genClasses>
+        <genClasses ecoreClass="SimpleML.ecore#//SmlLambdaParameterList" />
         <genClasses ecoreClass="SimpleML.ecore#//SmlBlockLambda">
             <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SimpleML.ecore#//SmlBlockLambda/body" />
         </genClasses>

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/SimpleML.xtext
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/SimpleML.xtext
@@ -255,7 +255,7 @@ SmlParameterList
     : {SmlParameterList} '(' (parameters+=SmlParameter (',' parameters+=SmlParameter)* ','?)? ')'
     ;
 
-// Only used temporarily while parsing lambdas to avoid left-recursion. Can be treated like a normal parameter list.
+// Used while parsing lambdas to avoid left-recursion. Can be treated like a normal parameter list.
 SmlLambdaParameterList
     : {SmlLambdaParameterList} '(' (parameters+=SmlParameter (',' parameters+=SmlParameter)* ','?)? ')'
     ;
@@ -325,7 +325,7 @@ SmlExpression returns SmlAbstractExpression
     | SmlOrExpression
     ;
 
-SmlLambda returns SmlAbstractLambda
+SmlLambda returns SmlAbstractExpression
     : SmlLambdaParameterList
     ( {SmlBlockLambda.parameterList=current}      body=SmlBlockLambdaBlock
     | {SmlExpressionLambda.parameterList=current} '->' result=SmlExpression

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
@@ -17,6 +17,7 @@ import de.unibonn.simpleml.simpleML.SmlAbstractCompilationUnitMember
 import de.unibonn.simpleml.simpleML.SmlAbstractConstraint
 import de.unibonn.simpleml.simpleML.SmlAbstractDeclaration
 import de.unibonn.simpleml.simpleML.SmlAbstractExpression
+import de.unibonn.simpleml.simpleML.SmlAbstractLambda
 import de.unibonn.simpleml.simpleML.SmlAbstractNamedTypeDeclaration
 import de.unibonn.simpleml.simpleML.SmlAbstractObject
 import de.unibonn.simpleml.simpleML.SmlAbstractProtocolTerm
@@ -52,6 +53,7 @@ import de.unibonn.simpleml.simpleML.SmlImportAlias
 import de.unibonn.simpleml.simpleML.SmlIndexedAccess
 import de.unibonn.simpleml.simpleML.SmlInfixOperation
 import de.unibonn.simpleml.simpleML.SmlInt
+import de.unibonn.simpleml.simpleML.SmlLambdaParameterList
 import de.unibonn.simpleml.simpleML.SmlMemberAccess
 import de.unibonn.simpleml.simpleML.SmlMemberType
 import de.unibonn.simpleml.simpleML.SmlNamedType
@@ -323,7 +325,7 @@ fun createSmlBlockLambda(
     init: SmlBlockLambda.() -> Unit = {}
 ): SmlBlockLambda {
     return factory.createSmlBlockLambda().apply {
-        this.parameterList = createSmlParameterList(parameters)
+        this.parameterList = createSmlLambdaParameterList(parameters)
         this.body = factory.createSmlBlock()
         statements.forEach { addStatement(it) }
         this.init()
@@ -607,7 +609,7 @@ fun createSmlExpressionLambda(
     result: SmlAbstractExpression
 ): SmlExpressionLambda {
     return factory.createSmlExpressionLambda().apply {
-        this.parameterList = createSmlParameterList(parameters)
+        this.parameterList = createSmlLambdaParameterList(parameters)
         this.result = result
     }
 }
@@ -865,6 +867,17 @@ fun createSmlParameter(
  */
 fun createSmlParameterList(parameters: List<SmlParameter>): SmlParameterList {
     return factory.createSmlParameterList().apply {
+        this.parameters += parameters
+    }
+}
+
+/**
+ * Returns a new object of class [SmlLambdaParameterList]. These have to be used as parameter lists of an
+ * [SmlAbstractLambda]
+ */
+@Suppress("FunctionName")
+fun createSmlLambdaParameterList(parameters: List<SmlParameter>): SmlLambdaParameterList {
+    return factory.createSmlLambdaParameterList().apply {
         this.parameters += parameters
     }
 }

--- a/DSL/de.unibonn.simpleml/src/test/kotlin/de/unibonn/simpleml/emf/CreatorsTest.kt
+++ b/DSL/de.unibonn.simpleml/src/test/kotlin/de/unibonn/simpleml/emf/CreatorsTest.kt
@@ -8,6 +8,7 @@ import de.unibonn.simpleml.serializer.SerializationResult
 import de.unibonn.simpleml.serializer.serializeToFormattedString
 import de.unibonn.simpleml.simpleML.SmlFloat
 import de.unibonn.simpleml.simpleML.SmlInt
+import de.unibonn.simpleml.simpleML.SmlLambdaParameterList
 import de.unibonn.simpleml.simpleML.SmlParameterList
 import de.unibonn.simpleml.simpleML.SmlPrefixOperation
 import de.unibonn.simpleml.simpleML.SmlProtocol
@@ -195,6 +196,25 @@ class CreatorsTest {
     }
 
     @Test
+    fun `createSmlBlockLambda should use a lambda parameter list for parameters`() {
+        val lambda = createSmlBlockLambda()
+        lambda.parameterList.shouldBeInstanceOf<SmlLambdaParameterList>()
+    }
+
+    @Test
+    fun `createSmlBlockLambda should create a serializable block lambda`() {
+        val lambda = createSmlBlockLambda()
+
+        createSmlDummyResource(fileName = "test", SmlFileExtension.Test, packageName = "test") {
+            smlWorkflow(name = "test") {
+                smlExpressionStatement(lambda)
+            }
+        }
+
+        lambda.serializeToFormattedString().shouldBeInstanceOf<SerializationResult.Success>()
+    }
+
+    @Test
     fun `createSmlCall should omit empty type argument lists`() {
         val call = createSmlCall(
             createSmlNull(),
@@ -374,6 +394,25 @@ class CreatorsTest {
         val body = enum.body
         body.shouldNotBeNull()
         body.variants.shouldHaveSize(1)
+    }
+
+    @Test
+    fun `createSmlExpressionLambda should use a lambda parameter list for parameters`() {
+        val lambda = createSmlExpressionLambda(result = createSmlNull())
+        lambda.parameterList.shouldBeInstanceOf<SmlLambdaParameterList>()
+    }
+
+    @Test
+    fun `createSmlExpressionLambda should create a serializable expression lambda`() {
+        val lambda = createSmlExpressionLambda(result = createSmlNull())
+
+        createSmlDummyResource(fileName = "test", SmlFileExtension.Test, packageName = "test") {
+            smlWorkflow(name = "test") {
+                smlExpressionStatement(lambda)
+            }
+        }
+
+        lambda.serializeToFormattedString().shouldBeInstanceOf<SerializationResult.Success>()
     }
 
     @Test


### PR DESCRIPTION
## Summary of Changes

The EMF model for lambdas built by creator functions was not serializable due to having the wrong EMF model structure. This PR fixes this.
