### PR TITLE
refactor: rename AnnotationCallHolder to AnnotationCallList

### DIFF
--- a/DSL/de.unibonn.simpleml/model/SimpleML.ecore
+++ b/DSL/de.unibonn.simpleml/model/SimpleML.ecore
@@ -5,7 +5,7 @@
         <eStructuralFeatures xsi:type="ecore:EReference" name="annotationCalls" upperBound="-1" eType="#//SmlAnnotationCall" containment="true" />
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="SmlAbstractDeclaration" abstract="true" eSuperTypes="#//SmlAbstractAnnotatedObject">
-        <eStructuralFeatures xsi:type="ecore:EReference" name="annotationCallHolder" eType="#//SmlAnnotationCallHolder" containment="true" />
+        <eStructuralFeatures xsi:type="ecore:EReference" name="annotationCallList" eType="#//SmlAnnotationCallList" containment="true" />
         <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" />
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="SmlAbstractCall" abstract="true" eSuperTypes="#//SmlAbstractObject">
@@ -23,7 +23,7 @@
     <eClassifiers xsi:type="ecore:EClass" name="SmlAnnotation" eSuperTypes="#//SmlAbstractCallable #//SmlAbstractCompilationUnitMember">
         <eStructuralFeatures xsi:type="ecore:EReference" name="constraintList" eType="#//SmlConstraintList" containment="true" />
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="SmlAnnotationCallHolder" eSuperTypes="#//SmlAbstractAnnotatedObject" />
+    <eClassifiers xsi:type="ecore:EClass" name="SmlAnnotationCallList" eSuperTypes="#//SmlAbstractAnnotatedObject" />
     <eClassifiers xsi:type="ecore:EClass" name="SmlAnnotationCall" eSuperTypes="#//SmlAbstractCall">
         <eStructuralFeatures xsi:type="ecore:EReference" name="annotation" eType="#//SmlAnnotation" />
     </eClassifiers>

--- a/DSL/de.unibonn.simpleml/model/SimpleML.genmodel
+++ b/DSL/de.unibonn.simpleml/model/SimpleML.genmodel
@@ -6,7 +6,7 @@
             <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SimpleML.ecore#//SmlAbstractAnnotatedObject/annotationCalls" />
         </genClasses>
         <genClasses image="false" ecoreClass="SimpleML.ecore#//SmlAbstractDeclaration">
-            <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SimpleML.ecore#//SmlAbstractAnnotatedObject/annotationCallHolder" />
+            <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SimpleML.ecore#//SmlAbstractAnnotatedObject/annotationCallList" />
             <genFeatures createChild="false" ecoreFeature="ecore:EAttribute SimpleML.ecore#//SmlAbstractDeclaration/name" />
         </genClasses>
         <genClasses image="false" ecoreClass="SimpleML.ecore#//SmlAbstractCallable">
@@ -21,7 +21,7 @@
         <genClasses ecoreClass="SimpleML.ecore#//SmlAnnotation">
             <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SimpleML.ecore#//SmlAnnotation/constraintList" />
         </genClasses>
-        <genClasses ecoreClass="SimpleML.ecore#//SmlAnnotationCallHolder" />
+        <genClasses ecoreClass="SimpleML.ecore#//SmlAnnotationCallList" />
         <genClasses ecoreClass="SimpleML.ecore#//SmlAnnotationCall">
             <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference SimpleML.ecore#//SmlAnnotationUse/annotation" />
             <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SimpleML.ecore#//SmlAnnotationUse/argumentList" />

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/SimpleML.xtext
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/SimpleML.xtext
@@ -24,14 +24,14 @@ SmlCompilationUnit
     ;
 
 SmlCompilationUnitMember returns SmlAbstractAnnotatedObject
-    : {SmlAnnotationCallHolder} annotationCalls+=SmlAnnotationCall*
+    : {SmlAnnotationCallList} annotationCalls+=SmlAnnotationCall*
 
-    ( {SmlAnnotation.annotationCallHolder=current}
+    ( {SmlAnnotation.annotationCallList=current}
           'annotation' name=ID
           parameterList=SmlParameterList?
           constraintList=SmlConstraintList?
 
-    | {SmlClass.annotationCallHolder=current}
+    | {SmlClass.annotationCallList=current}
           'class' name=ID
           typeParameterList=SmlTypeParameterList?
           parameterList=SmlParameterList?
@@ -39,25 +39,25 @@ SmlCompilationUnitMember returns SmlAbstractAnnotatedObject
           constraintList=SmlConstraintList?
           body=SmlClassBody?
 
-    | {SmlEnum.annotationCallHolder=current}
+    | {SmlEnum.annotationCallList=current}
           'enum' name=ID
           body=SmlEnumBody?
 
-    | {SmlFunction.annotationCallHolder=current}
+    | {SmlFunction.annotationCallList=current}
           'fun' name=ID
           typeParameterList=SmlTypeParameterList?
           parameterList=SmlParameterList
           resultList=SmlResultList?
           constraintList=SmlConstraintList?
 
-    | {SmlStep.annotationCallHolder=current}
+    | {SmlStep.annotationCallList=current}
           visibility=('internal'|'private')?
           'step' name=ID
           parameterList=SmlParameterList
           resultList=SmlResultList?
           body=SmlBlock
 
-    | {SmlWorkflow.annotationCallHolder=current}
+    | {SmlWorkflow.annotationCallList=current}
           'workflow' name=ID
           body=SmlBlock
     )
@@ -116,13 +116,13 @@ SmlClassMember returns SmlAbstractObject
     ;
 
 SmlAnnotatedClassMember returns SmlAbstractAnnotatedObject
-    : {SmlAnnotationCallHolder} annotationCalls+=SmlAnnotationCall*
+    : {SmlAnnotationCallList} annotationCalls+=SmlAnnotationCall*
 
-    ( {SmlAttribute.annotationCallHolder=current}
+    ( {SmlAttribute.annotationCallList=current}
           static?='static'?
           'attr' name=ID (':' type=SmlType)?
 
-    | {SmlClass.annotationCallHolder=current}
+    | {SmlClass.annotationCallList=current}
           'class' name=ID
           typeParameterList=SmlTypeParameterList?
           parameterList=SmlParameterList?
@@ -130,11 +130,11 @@ SmlAnnotatedClassMember returns SmlAbstractAnnotatedObject
           constraintList=SmlConstraintList?
           body=SmlClassBody?
 
-    | {SmlEnum.annotationCallHolder=current}
+    | {SmlEnum.annotationCallList=current}
           'enum' name=ID
           body=SmlEnumBody?
 
-    | {SmlFunction.annotationCallHolder=current}
+    | {SmlFunction.annotationCallList=current}
           static?='static'?
           'fun' name=ID
           typeParameterList=SmlTypeParameterList?

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
@@ -26,7 +26,7 @@ import de.unibonn.simpleml.simpleML.SmlAbstractType
 import de.unibonn.simpleml.simpleML.SmlAbstractTypeArgumentValue
 import de.unibonn.simpleml.simpleML.SmlAnnotation
 import de.unibonn.simpleml.simpleML.SmlAnnotationCall
-import de.unibonn.simpleml.simpleML.SmlAnnotationCallHolder
+import de.unibonn.simpleml.simpleML.SmlAnnotationCallList
 import de.unibonn.simpleml.simpleML.SmlArgument
 import de.unibonn.simpleml.simpleML.SmlArgumentList
 import de.unibonn.simpleml.simpleML.SmlAssigneeList
@@ -146,7 +146,7 @@ fun createSmlAnnotation(
 ): SmlAnnotation {
     return factory.createSmlAnnotation().apply {
         this.name = name
-        this.annotationCallHolder = createSmlAnnotationCallHolder(annotationCalls)
+        this.annotationCallList = createSmlAnnotationCallList(annotationCalls)
         this.parameterList = parameters.nullIfEmptyElse(::createSmlParameterList)
     }
 }
@@ -189,10 +189,10 @@ fun createSmlAnnotationCall(
 }
 
 /**
- * Returns a new object of class [SmlAnnotationCallHolder].
+ * Returns a new object of class [SmlAnnotationCallList].
  */
-private fun createSmlAnnotationCallHolder(annotationCalls: List<SmlAnnotationCall>): SmlAnnotationCallHolder {
-    return factory.createSmlAnnotationCallHolder().apply {
+private fun createSmlAnnotationCallList(annotationCalls: List<SmlAnnotationCall>): SmlAnnotationCallList {
+    return factory.createSmlAnnotationCallList().apply {
         this.annotationCalls += annotationCalls
     }
 }
@@ -283,7 +283,7 @@ fun createSmlAttribute(
 ): SmlAttribute {
     return factory.createSmlAttribute().apply {
         this.name = name
-        this.annotationCallHolder = createSmlAnnotationCallHolder(annotationCalls)
+        this.annotationCallList = createSmlAnnotationCallList(annotationCalls)
         this.isStatic = isStatic
         this.type = type
     }
@@ -400,7 +400,7 @@ fun createSmlClass(
 ): SmlClass {
     return factory.createSmlClass().apply {
         this.name = name
-        this.annotationCallHolder = createSmlAnnotationCallHolder(annotationCalls)
+        this.annotationCallList = createSmlAnnotationCallList(annotationCalls)
         this.typeParameterList = typeParameters.nullIfEmptyElse(::createSmlTypeParameterList)
         this.parameterList = parameters?.nullIfEmptyElse(::createSmlParameterList)
         this.parentTypeList = parentTypes.nullIfEmptyElse(::createSmlParentTypeList)
@@ -526,7 +526,7 @@ fun createSmlEnum(
 ): SmlEnum {
     return factory.createSmlEnum().apply {
         this.name = name
-        this.annotationCallHolder = createSmlAnnotationCallHolder(annotationCalls)
+        this.annotationCallList = createSmlAnnotationCallList(annotationCalls)
         variants.forEach { addVariant(it) }
         this.init()
     }
@@ -671,7 +671,7 @@ fun createSmlFunction(
 ): SmlFunction {
     return factory.createSmlFunction().apply {
         this.name = name
-        this.annotationCallHolder = createSmlAnnotationCallHolder(annotationCalls)
+        this.annotationCallList = createSmlAnnotationCallList(annotationCalls)
         this.isStatic = isStatic
         this.typeParameterList = typeParameters.nullIfEmptyElse(::createSmlTypeParameterList)
         this.parameterList = createSmlParameterList(parameters)
@@ -1118,7 +1118,7 @@ fun createSmlStep(
 ): SmlStep {
     return factory.createSmlStep().apply {
         this.name = name
-        this.annotationCallHolder = createSmlAnnotationCallHolder(annotationCalls)
+        this.annotationCallList = createSmlAnnotationCallList(annotationCalls)
         this.visibility = visibility.visibility
         this.parameterList = createSmlParameterList(parameters)
         this.resultList = results.nullIfEmptyElse(::createSmlResultList)
@@ -1359,7 +1359,7 @@ fun createSmlWorkflow(
 ): SmlWorkflow {
     return factory.createSmlWorkflow().apply {
         this.name = name
-        this.annotationCallHolder = createSmlAnnotationCallHolder(annotationCalls)
+        this.annotationCallList = createSmlAnnotationCallList(annotationCalls)
         this.body = factory.createSmlBlock()
         statements.forEach { addStatement(it) }
         this.init()

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/SimpleShortcuts.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/SimpleShortcuts.kt
@@ -21,7 +21,7 @@ import de.unibonn.simpleml.simpleML.SmlAbstractStatement
 import de.unibonn.simpleml.simpleML.SmlAbstractType
 import de.unibonn.simpleml.simpleML.SmlAnnotation
 import de.unibonn.simpleml.simpleML.SmlAnnotationCall
-import de.unibonn.simpleml.simpleML.SmlAnnotationCallHolder
+import de.unibonn.simpleml.simpleML.SmlAnnotationCallList
 import de.unibonn.simpleml.simpleML.SmlArgument
 import de.unibonn.simpleml.simpleML.SmlAssignment
 import de.unibonn.simpleml.simpleML.SmlAttribute
@@ -94,7 +94,7 @@ fun SmlAbstractCallable.immediateCalls(): List<SmlCall> {
 // SmlAbstractDeclaration --------------------------------------------------------------------------
 
 fun SmlAbstractDeclaration?.annotationCallsOrEmpty(): List<SmlAnnotationCall> {
-    return this?.annotationCallHolder?.annotationCalls ?: this?.annotationCalls.orEmpty()
+    return this?.annotationCallList?.annotationCalls ?: this?.annotationCalls.orEmpty()
 }
 
 // SmlAnnotation -----------------------------------------------------------------------------------
@@ -345,7 +345,7 @@ fun EObject.containingWorkflowOrNull() = this.closestAncestorOrNull<SmlWorkflow>
 
 fun SmlAnnotationCall.targetOrNull(): SmlAbstractDeclaration? {
     return when (val declaration = this.containingDeclarationOrNull() ?: return null) {
-        is SmlAnnotationCallHolder -> declaration.containingDeclarationOrNull()
+        is SmlAnnotationCallList -> declaration.containingDeclarationOrNull()
         else -> declaration
     }
 }

--- a/DSL/de.unibonn.simpleml/src/test/kotlin/de/unibonn/simpleml/emf/CreatorsTest.kt
+++ b/DSL/de.unibonn.simpleml/src/test/kotlin/de/unibonn/simpleml/emf/CreatorsTest.kt
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  * Includes tests for the (extension) functions in Creators.kt. Since most of the functions are straightforward, not
  * everything is being tested. These are the guidelines for what should be tested:
  *
- * - Handling of annotations (features annotationCallHolder vs. annotations)
+ * - Handling of annotations (features annotationCallList vs. annotations)
  * - Extension functions should add created object to receiver
  * - Creators for objects with cross-references that take a name instead of the referenced object
  * - Should not create unnecessary syntax (like empty class bodies)
@@ -57,7 +57,7 @@ class CreatorsTest {
     }
 
     @Test
-    fun `createSmlAnnotation should store annotation uses in annotationCallHolder`() {
+    fun `createSmlAnnotation should store annotation uses in annotationCallList`() {
         val annotation = createSmlAnnotation(
             "Test",
             listOf(createSmlAnnotationCall("Test"))
@@ -65,9 +65,9 @@ class CreatorsTest {
 
         annotation.annotationCalls.shouldHaveSize(0)
 
-        val annotationCallHolder = annotation.annotationCallHolder
-        annotationCallHolder.shouldNotBeNull()
-        annotationCallHolder.annotationCalls.shouldHaveSize(1)
+        val annotationCallList = annotation.annotationCallList
+        annotationCallList.shouldNotBeNull()
+        annotationCallList.annotationCalls.shouldHaveSize(1)
     }
 
     @Test
@@ -164,7 +164,7 @@ class CreatorsTest {
     }
 
     @Test
-    fun `createSmlAttribute should store annotation uses in annotationCallHolder`() {
+    fun `createSmlAttribute should store annotation uses in annotationCallList`() {
         val attribute = createSmlAttribute(
             "Test",
             listOf(createSmlAnnotationCall("Test"))
@@ -172,9 +172,9 @@ class CreatorsTest {
 
         attribute.annotationCalls.shouldHaveSize(0)
 
-        val annotationCallHolder = attribute.annotationCallHolder
-        annotationCallHolder.shouldNotBeNull()
-        annotationCallHolder.annotationCalls.shouldHaveSize(1)
+        val annotationCallList = attribute.annotationCallList
+        annotationCallList.shouldNotBeNull()
+        annotationCallList.annotationCalls.shouldHaveSize(1)
     }
 
     @Test
@@ -204,7 +204,7 @@ class CreatorsTest {
     }
 
     @Test
-    fun `createSmlClass should store annotation uses in annotationCallHolder`() {
+    fun `createSmlClass should store annotation uses in annotationCallList`() {
         val `class` = createSmlClass(
             "Test",
             listOf(createSmlAnnotationCall("Test"))
@@ -212,9 +212,9 @@ class CreatorsTest {
 
         `class`.annotationCalls.shouldHaveSize(0)
 
-        val annotationCallHolder = `class`.annotationCallHolder
-        annotationCallHolder.shouldNotBeNull()
-        annotationCallHolder.annotationCalls.shouldHaveSize(1)
+        val annotationCallList = `class`.annotationCallList
+        annotationCallList.shouldNotBeNull()
+        annotationCallList.annotationCalls.shouldHaveSize(1)
     }
 
     @Test
@@ -281,11 +281,11 @@ class CreatorsTest {
         )
 
         compilationUnit.annotationCalls.shouldHaveSize(1)
-        compilationUnit.annotationCallHolder.shouldBeNull()
+        compilationUnit.annotationCallList.shouldBeNull()
     }
 
     @Test
-    fun `createSmlEnum should store annotation uses in annotationCallHolder`() {
+    fun `createSmlEnum should store annotation uses in annotationCallList`() {
         val `enum` = createSmlEnum(
             "Test",
             listOf(createSmlAnnotationCall("Test"))
@@ -293,9 +293,9 @@ class CreatorsTest {
 
         `enum`.annotationCalls.shouldHaveSize(0)
 
-        val annotationCallHolder = `enum`.annotationCallHolder
-        annotationCallHolder.shouldNotBeNull()
-        annotationCallHolder.annotationCalls.shouldHaveSize(1)
+        val annotationCallList = `enum`.annotationCallList
+        annotationCallList.shouldNotBeNull()
+        annotationCallList.annotationCalls.shouldHaveSize(1)
     }
 
     @Test
@@ -335,7 +335,7 @@ class CreatorsTest {
         )
 
         variant.annotationCalls.shouldHaveSize(1)
-        variant.annotationCallHolder.shouldBeNull()
+        variant.annotationCallList.shouldBeNull()
     }
 
     @Test
@@ -422,7 +422,7 @@ class CreatorsTest {
     }
 
     @Test
-    fun `createSmlFunction should store annotation uses in annotationCallHolder`() {
+    fun `createSmlFunction should store annotation uses in annotationCallList`() {
         val function = createSmlFunction(
             "test",
             listOf(createSmlAnnotationCall("Test"))
@@ -430,9 +430,9 @@ class CreatorsTest {
 
         function.annotationCalls.shouldHaveSize(0)
 
-        val annotationCallHolder = function.annotationCallHolder
-        annotationCallHolder.shouldNotBeNull()
-        annotationCallHolder.annotationCalls.shouldHaveSize(1)
+        val annotationCallList = function.annotationCallList
+        annotationCallList.shouldNotBeNull()
+        annotationCallList.annotationCalls.shouldHaveSize(1)
     }
 
     @Test
@@ -511,7 +511,7 @@ class CreatorsTest {
         )
 
         parameter.annotationCalls.shouldHaveSize(1)
-        parameter.annotationCallHolder.shouldBeNull()
+        parameter.annotationCallList.shouldBeNull()
     }
 
     @Test
@@ -604,7 +604,7 @@ class CreatorsTest {
         )
 
         result.annotationCalls.shouldHaveSize(1)
-        result.annotationCallHolder.shouldBeNull()
+        result.annotationCallList.shouldBeNull()
     }
 
     @Test
@@ -675,7 +675,7 @@ class CreatorsTest {
         )
 
         result.annotationCalls.shouldHaveSize(1)
-        result.annotationCallHolder.shouldBeNull()
+        result.annotationCallList.shouldBeNull()
     }
 
     @Test
@@ -716,7 +716,7 @@ class CreatorsTest {
     }
 
     @Test
-    fun `createSmlStep should store annotation uses in annotationCallHolder`() {
+    fun `createSmlStep should store annotation uses in annotationCallList`() {
         val step = createSmlStep(
             "test",
             listOf(createSmlAnnotationCall("Test"))
@@ -724,9 +724,9 @@ class CreatorsTest {
 
         step.annotationCalls.shouldHaveSize(0)
 
-        val annotationCallHolder = step.annotationCallHolder
-        annotationCallHolder.shouldNotBeNull()
-        annotationCallHolder.annotationCalls.shouldHaveSize(1)
+        val annotationCallList = step.annotationCallList
+        annotationCallList.shouldNotBeNull()
+        annotationCallList.annotationCalls.shouldHaveSize(1)
     }
 
     @Test
@@ -748,7 +748,7 @@ class CreatorsTest {
     }
 
     @Test
-    fun `createSmlWorkflow should store annotation uses in annotationCallHolder`() {
+    fun `createSmlWorkflow should store annotation uses in annotationCallList`() {
         val workflow = createSmlWorkflow(
             "test",
             listOf(createSmlAnnotationCall("Test"))
@@ -756,9 +756,9 @@ class CreatorsTest {
 
         workflow.annotationCalls.shouldHaveSize(0)
 
-        val annotationCallHolder = workflow.annotationCallHolder
-        annotationCallHolder.shouldNotBeNull()
-        annotationCallHolder.annotationCalls.shouldHaveSize(1)
+        val annotationCallList = workflow.annotationCallList
+        annotationCallList.shouldNotBeNull()
+        annotationCallList.annotationCalls.shouldHaveSize(1)
     }
 
     @Test


### PR DESCRIPTION
## Summary of Changes

Rename `AnnotationCallHolder` to `AnnotationCallList` to be inline with other lists.