### PR TITLE
build: bump Docker base image for runtime

### DIFF
--- a/Runtime/Dockerfile
+++ b/Runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.9.2-alpine
+FROM continuumio/miniconda3:4.10.3-alpine
 
 COPY environment.yml ./
 RUN conda env create -f environment.yml


### PR DESCRIPTION
## Summary of Changes

* Bump Docker base image for runtime from 4.9.2 to 4.10.3