### PR TITLE
ci: use Dependabot to keep Dockerfiles updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/DSL"
     schedule:
-      interval: "monthly"  
+      interval: "monthly"
   - package-ecosystem: "gradle"
     directory: "/DSL"
     schedule:
@@ -29,7 +29,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/Frontend"
     schedule:
-      interval: "monthly" 
+      interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/Frontend"
     schedule:


### PR DESCRIPTION
## Summary of Changes

* Use Dependabot to keep Dockerfiles updated
