### PR TITLE
ci: basic config for flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+ignore =
+    # line too long (black handles that)
+    E501
+per-file-ignores =
+    # imported but unused
+    __init__.py: F401


### PR DESCRIPTION
## Summary of Changes

The standard config of flake8 contains some rules that are already covered more thoroughly by other linters are that are just pointless in some situations. This PR disables these rules.
