### PR TITLE
build: downgrade Node.js to 14

### DIFF
--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine as builder
+FROM node:14-alpine as builder
 
 WORKDIR /tmp/
 
@@ -9,7 +9,7 @@ COPY . /tmp/
 RUN npm run build
 
 
-FROM node:16-alpine as runner
+FROM node:14-alpine as runner
 
 WORKDIR /app/
 


### PR DESCRIPTION
## Summary of Changes

Downgrade Node.js to 14 in Docker image to fix build error:

```
#17 7.374 npm ERR! code ERESOLVE
#17 7.382 npm ERR! ERESOLVE unable to resolve dependency tree
#17 7.385 npm ERR! While resolving: xtext-frontend@0.1.0
#17 7.385 npm ERR! Found: react@16.14.0
#17 7.385 npm ERR! node_modules/react
#17 7.385 npm ERR!   react@"^16.8.6" from the root project
#17 7.385 npm ERR!   peer react@">=16.8.0" from @emotion/react@11.8.1
#17 7.385 npm ERR!   node_modules/@emotion/react
#17 7.386 npm ERR!     @emotion/react@"^11.8.1" from the root project
#17 7.386 npm ERR!     peerOptional @emotion/react@"^11.5.0" from @mui/material@5.5.0
#17 7.386 npm ERR!     node_modules/@mui/material
#17 7.386 npm ERR!       @mui/material@"^5.4.3" from the root project
#17 7.386 npm ERR!     1 more (@emotion/styled)
#17 7.386 npm ERR!   1 more (@emotion/styled)
#17 7.386 npm ERR!
#17 7.386 npm ERR! Could not resolve dependency:
#17 7.386 npm ERR! peer react@"^17.0.0" from @mui/material@5.5.0
#17 7.386 npm ERR! node_modules/@mui/material
#17 7.386 npm ERR!   @mui/material@"^5.4.3" from the root project
#17 7.387 npm ERR!
#17 7.387 npm ERR! Fix the upstream dependency conflict, or retry
#17 7.387 npm ERR! this command with --force, or --legacy-peer-deps
#17 7.387 npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
#17 7.387 npm ERR!
#17 7.387 npm ERR! See /root/.npm/eresolve-report.txt for a full report.
#17 7.390
#17 7.390 npm ERR! A complete log of this run can be found in:
#17 7.390 npm ERR!     /root/.npm/_logs/2022-03-07T15_14_19_107Z-debug-0.log
```
