### PR TITLE
fix: codegen for member accesses of enum variants

### DIFF
--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/generator/SimpleMLGenerator.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/generator/SimpleMLGenerator.kt
@@ -37,6 +37,7 @@ import de.unibonn.simpleml.simpleML.SmlBlockLambda
 import de.unibonn.simpleml.simpleML.SmlBlockLambdaResult
 import de.unibonn.simpleml.simpleML.SmlCall
 import de.unibonn.simpleml.simpleML.SmlCompilationUnit
+import de.unibonn.simpleml.simpleML.SmlEnumVariant
 import de.unibonn.simpleml.simpleML.SmlExpressionLambda
 import de.unibonn.simpleml.simpleML.SmlExpressionStatement
 import de.unibonn.simpleml.simpleML.SmlIndexedAccess
@@ -523,6 +524,23 @@ class SimpleMLGenerator : AbstractGenerator() {
                             } else {
                                 val thisIndex = allResults.indexOf(memberDeclaration)
                                 "$receiver[$thisIndex]"
+                            }
+                        }
+                        is SmlEnumVariant -> {
+                            val member =
+                                callRecursive(CompileExpressionFrame(expr.member, imports, blockLambdaIdManager))
+
+                            val suffix = when (expr.eContainer()) {
+                                is SmlCall -> ""
+                                else -> "()"
+                            }
+
+                            when {
+                                expr.isNullSafe -> {
+                                    imports += ImportData(codegenPackage)
+                                    "$codegenPackage.safe_access($receiver, '$member')$suffix"
+                                }
+                                else -> "$receiver.$member$suffix"
                             }
                         }
                         is SmlResult -> {

--- a/DSL/de.unibonn.simpleml/src/test/resources/generator/expressions/enum variant call/input.smltest
+++ b/DSL/de.unibonn.simpleml/src/test/resources/generator/expressions/enum variant call/input.smltest
@@ -1,0 +1,16 @@
+// Related to https://github.com/lars-reimann/Simple-ML/issues/118
+
+package tests.generator.enumVariantCall
+
+fun f(p: Any)
+
+enum MyEnum {
+   Variant1
+   Variant2(counter: Int)
+}
+
+workflow test {
+   f(MyEnum.Variant1);
+   f(MyEnum.Variant1());
+   f(MyEnum.Variant2(1));
+}

--- a/DSL/de.unibonn.simpleml/src/test/resources/generator/expressions/enum variant call/output/tests/generator/enumVariantCall/gen_input.py
+++ b/DSL/de.unibonn.simpleml/src/test/resources/generator/expressions/enum variant call/output/tests/generator/enumVariantCall/gen_input.py
@@ -1,0 +1,6 @@
+# Workflows --------------------------------------------------------------------
+
+def test():
+    f(MyEnum.Variant1())
+    f(MyEnum.Variant1())
+    f(MyEnum.Variant2(1))

--- a/DSL/de.unibonn.simpleml/src/test/resources/generator/expressions/enum variant call/output/tests/generator/enumVariantCall/gen_input_test.py
+++ b/DSL/de.unibonn.simpleml/src/test/resources/generator/expressions/enum variant call/output/tests/generator/enumVariantCall/gen_input_test.py
@@ -1,0 +1,4 @@
+from gen_input import test
+
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
Closes https://github.com/lars-reimann/Simple-ML/issues/118.

## Summary of Changes

* Fixes the linked issue by ensuring calls are created when accessing enum variants.
