### PR TITLE
feat: don't mark placeholders in last statement in block as unused

### DIFF
--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/declarations/PlaceholderChecker.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/declarations/PlaceholderChecker.kt
@@ -2,6 +2,7 @@ package de.unibonn.simpleml.validation.declarations
 
 import de.unibonn.simpleml.emf.closestAncestorOrNull
 import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals
+import de.unibonn.simpleml.simpleML.SmlAssignment
 import de.unibonn.simpleml.simpleML.SmlBlock
 import de.unibonn.simpleml.simpleML.SmlClass
 import de.unibonn.simpleml.simpleML.SmlEnum
@@ -34,7 +35,8 @@ class PlaceholderChecker : AbstractSimpleMLChecker() {
     @Check
     fun unused(smlPlaceholder: SmlPlaceholder) {
         val block = smlPlaceholder.closestAncestorOrNull<SmlBlock>() ?: return
-        if (smlPlaceholder.usesIn(block).none()) {
+        val assignment = smlPlaceholder.closestAncestorOrNull<SmlAssignment>() ?: return
+        if (assignment != block.statements.lastOrNull() && smlPlaceholder.usesIn(block).none()) {
             warning(
                 "This placeholder is unused.",
                 Literals.SML_ABSTRACT_DECLARATION__NAME,

--- a/DSL/de.unibonn.simpleml/src/test/resources/validation/declarations/placeholders/unused.smltest
+++ b/DSL/de.unibonn.simpleml/src/test/resources/validation/declarations/placeholders/unused.smltest
@@ -9,9 +9,12 @@ step myFunction() {
     // no_semantic_warning "This placeholder is unused."
     val »used« = 1;
     call(used);
+
+    // no_semantic_warning "This placeholder is unused."
+    val »last« = 1;
 }
 
-workflow myWorkflow {
+workflow myWorkflow1 {
     call(unused);
 
     // semantic_warning "This placeholder is unused."
@@ -20,4 +23,23 @@ workflow myWorkflow {
     // no_semantic_warning "This placeholder is unused."
     val »used« = 1;
     call(used);
+
+    // no_semantic_warning "This placeholder is unused."
+    val »last« = 1;
+}
+
+workflow myWorkflow2 {
+    () {
+        call(unused);
+
+        // semantic_warning "This placeholder is unused."
+        val »unused« = 1;
+
+        // no_semantic_warning "This placeholder is unused."
+        val »used« = 1;
+        call(used);
+
+        // no_semantic_warning "This placeholder is unused."
+        val »last« = 1;
+    };
 }


### PR DESCRIPTION
Closes https://github.com/lars-reimann/Simple-ML/issues/120.

## Summary of Changes

Previously, any placeholders in the final statement in a block would always be marked as unused. However, it is not even possible to refer to these placeholders in the first place since forward references are not allowed. This meant that many unnecessary and unhelpful warnings were shown as the program was being written.

This PR disables the warning for the final statement in a block.