### PR TITLE
fix: create empty parameter lists for classes

### DIFF
--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
@@ -404,7 +404,7 @@ fun createSmlClass(
         this.name = name
         this.annotationCallList = createSmlAnnotationCallList(annotationCalls)
         this.typeParameterList = typeParameters.nullIfEmptyElse(::createSmlTypeParameterList)
-        this.parameterList = parameters?.nullIfEmptyElse(::createSmlParameterList)
+        this.parameterList = parameters?.let { createSmlParameterList(it) }
         this.parentTypeList = parentTypes.nullIfEmptyElse(::createSmlParentTypeList)
         this.constraintList = constraints.nullIfEmptyElse(::createSmlConstraintList)
         protocol?.let { addMember(it) }

--- a/DSL/de.unibonn.simpleml/src/test/kotlin/de/unibonn/simpleml/emf/CreatorsTest.kt
+++ b/DSL/de.unibonn.simpleml/src/test/kotlin/de/unibonn/simpleml/emf/CreatorsTest.kt
@@ -247,6 +247,15 @@ class CreatorsTest {
     }
 
     @Test
+    fun `createSmlClass should not omit empty parameter lists`() {
+        val `class` = createSmlClass(
+            "Test",
+            parameters = emptyList()
+        )
+        `class`.parameterList.shouldBeInstanceOf<SmlParameterList>()
+    }
+
+    @Test
     fun `createSmlClass should omit empty parent type list`() {
         val `class` = createSmlClass(
             "Test",


### PR DESCRIPTION
## Summary of Changes

Previously, the creators would not add empty parameter lists to classes, so they could not be instantiated. This PR fixes this.